### PR TITLE
updated threaded mode to allow rake tasks

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,7 +53,7 @@ AdoptAThing::Application.configure do
   config.action_mailer.default_url_options = {:host => 'adoptahydrant.org'}
 
   # Enable threaded mode
-  config.threadsafe!
+  config.threadsafe! unless $rails_rake_task
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation can not be found)


### PR DESCRIPTION
`rake db:seed` cannot run in production (Heroku in my case) if threaded mode is enabled as is. The solution is to add `unless $rails_rake_task` after `config.threadsafe!`. This will be the new default in Rails 4: https://github.com/rails/rails/issues/2662
