### PR TITLE
Update marker display on zoom as well as pan

### DIFF
--- a/app/assets/javascripts/main.js.erb
+++ b/app/assets/javascripts/main.js.erb
@@ -128,7 +128,7 @@ $(function() {
       }
     });
   }
-  google.maps.event.addListener(map, 'dragend', function() {
+  google.maps.event.addListener(map, 'idle', function() {
     var center = map.getCenter();
     addMarkersAround(center.lat(), center.lng());
   });


### PR DESCRIPTION
The app was using the 'dragend' event on the map to listen for
changes that should prompt the display of markers, but that event
only triggers when the map is panned. Changing to the 'idle' event
ensures that the display is updated on both zoom and pan instead
of requiring users to slightly pan the map after zooming to get
new data.

This has the side effect of making the initial markers display
immediately upon loading the page, rather than waiting for the user
to pan, as the idle event occurs when the map is initially loaded.
