### PR TITLE
moved secret token to ENV variable & updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,39 @@ This application requires [Postgres](http://www.postgresql.org/) to be installed
 ## Seed Data
     bundle exec rake db:seed
 
+## Deploying to Heroku
+A successful deployment to Heroku requires a few setup steps:
+
+1. Generate a new secret token:
+
+    ```
+    rake secret
+    ```
+
+2. Set the token on Heroku:
+
+    ```
+    heroku config:set SECRET_TOKEN=the_token_you_generated
+    ```
+
+3. [Precompile your assets](https://devcenter.heroku.com/articles/rails3x-asset-pipeline-cedar)
+
+    ```
+    RAILS_ENV=production bundle exec rake assets:precompile
+
+    git add public/assets
+
+    git commit -m "vendor compiled assets"
+    ```
+
+4. Add a production database to config/database.yml
+
+5. Seed the production db:
+
+    `heroku run bundle exec rake db:seed`
+
+6. Keep in mind that the Heroku free Postgres plan only allows up to 10,000 rows, so if your city has more than 10,000 fire hydrants (or other thing to be adopted), you will need to upgrade to the $9/month plan. 
+
 ## Contributing
 In the spirit of [free software][free-sw], **everyone** is encouraged to help
 improve this project.

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -4,4 +4,9 @@
 # If you change this key, all old signed cookies will become invalid!
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
-AdoptAThing::Application.config.secret_token = '4dc0354d5050c89c7f151a0bae3d2a7506a7ca66435ae9e0eb6754cb4be808089c7726c65dc8ae9b49870507fbe0de1fa36fa703491078b2c7122897892d6f69'
+if Rails.env.production? && ENV['SECRET_TOKEN'].blank?
+	raise 'The SECRET_TOKEN environment variable is not set.\n
+	To generate it, run "rake secret", then set it with "heroku config:set SECRET_TOKEN=the_token_you_generated"'
+end
+
+AdoptAThing::Application.config.secret_token = ENV['SECRET_TOKEN'] || '4dc0354d5050c89c7f151a0bae3d2a7506a7ca66435ae9e0eb6754cb4be808089c7726c65dc8ae9b49870507fbe0de1fa36fa703491078b2c7122897892d6f69'


### PR DESCRIPTION
I think it's a good practice to not expose secret tokens for open source apps.Modifying secret_token.rb to point to the SECRET_TOKEN environment variable requires setting the token on Heroku. I updated the README to include those instructions, in addition to other steps essential to a successful deployment.
