### PR TITLE
set jquery version at 1.8.3

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -9,8 +9,8 @@
     /[if lt IE 9]
       = javascript_include_tag "http://html5shim.googlecode.com/svn/trunk/html5.js"
     = javascript_include_tag "http://maps.google.com/maps/api/js?sensor=false&language=#{I18n.locale}"
-    = javascript_include_tag "http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"
-    = javascript_include_tag "http://ajax.googleapis.com/ajax/libs/jqueryui/1/jquery-ui.min.js"
+    = javascript_include_tag "http://ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"
+    = javascript_include_tag "http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.24/jquery-ui.min.js"
     = javascript_include_tag "application"
     %script{:type => "text/javascript"}
       var _gaq=_gaq||[];_gaq.push(["_setAccount","UA-20825280-2"]),_gaq.push(["_setDomainName",".adoptahydrant.org"]),_gaq.push(["_trackPageview"]),function(){var a=document.createElement("script");a.type="text/javascript",a.async=!0,a.src=("https:"==document.location.protocol?"https://ssl":"http://www")+".google-analytics.com/ga.js";var b=document.getElementsByTagName("script")[0];b.parentNode.insertBefore(a,b)}();


### PR DESCRIPTION
We are loading jquery from google, but only specify 1.x, Google is now serving up jquery 1.9 which breaks the version of bootstrap js file we are using. As a quick fix I set the version at 1.8.3
