### PR TITLE
HTTPS to access CDN

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,10 +7,10 @@
     %meta{:name => "viewport", :content => "width=800, user-scalable=no"}
     / HTML5 shim, for IE6-8 support of HTML5 elements
     /[if lt IE 9]
-      = javascript_include_tag "http://html5shim.googlecode.com/svn/trunk/html5.js"
-    = javascript_include_tag "http://maps.google.com/maps/api/js?sensor=false&language=#{I18n.locale}"
-    = javascript_include_tag "http://ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"
-    = javascript_include_tag "http://ajax.googleapis.com/ajax/libs/jqueryui/1.8.24/jquery-ui.min.js"
+      = javascript_include_tag "https://html5shim.googlecode.com/svn/trunk/html5.js"
+    = javascript_include_tag "https://maps.google.com/maps/api/js?sensor=false&language=#{I18n.locale}"
+    = javascript_include_tag "https://ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"
+    = javascript_include_tag "https://ajax.googleapis.com/ajax/libs/jqueryui/1.8.24/jquery-ui.min.js"
     = javascript_include_tag "application"
     %script{:type => "text/javascript"}
       var _gaq=_gaq||[];_gaq.push(["_setAccount","UA-20825280-2"]),_gaq.push(["_setDomainName",".adoptahydrant.org"]),_gaq.push(["_trackPageview"]),function(){var a=document.createElement("script");a.type="text/javascript",a.async=!0,a.src=("https:"==document.location.protocol?"https://ssl":"http://www")+".google-analytics.com/ga.js";var b=document.getElementsByTagName("script")[0];b.parentNode.insertBefore(a,b)}();


### PR DESCRIPTION
When used on secure connection, bypass the warning by using HTTPs by default.
