### PR TITLE
Support zoom in via mouse double clicks

### DIFF
--- a/app/assets/javascripts/main.js.erb
+++ b/app/assets/javascripts/main.js.erb
@@ -2,7 +2,7 @@ $(function() {
   var center = new google.maps.LatLng(42.358431, -71.059773);
   var mapOptions = {
     center: center,
-    disableDoubleClickZoom: true,
+    disableDoubleClickZoom: false,
     keyboardShortcuts: false,
     mapTypeControl: false,
     mapTypeId: google.maps.MapTypeId.ROADMAP,


### PR DESCRIPTION
Supports double clicking to zoom-in the map view.  Useful as a shortcut to view map-things.
