### PR TITLE
Add support for google maps API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,15 @@ A successful deployment to Heroku requires a few setup steps:
     heroku config:set SECRET_TOKEN=the_token_you_generated
     ```
 
-3. [Precompile your assets](https://devcenter.heroku.com/articles/rails3x-asset-pipeline-cedar)
+3. [Obtain a Google API Key](https://developers.google.com/maps/documentation/javascript/get-api-key).
+
+4. Set the Google API key:
+
+    ```
+    heroku config:set GOOGLE_MAP_KEY=the_token_you_obtained
+    ```
+
+5. [Precompile your assets](https://devcenter.heroku.com/articles/rails3x-asset-pipeline-cedar)
 
     ```
     RAILS_ENV=production bundle exec rake assets:precompile
@@ -60,9 +68,9 @@ A successful deployment to Heroku requires a few setup steps:
     git commit -m "vendor compiled assets"
     ```
 
-4. Add a production database to config/database.yml
+6. Add a production database to config/database.yml
 
-5. Seed the production db:
+7. Seed the production db:
 
     `heroku run bundle exec rake db:seed`
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -8,7 +8,7 @@
     / HTML5 shim, for IE6-8 support of HTML5 elements
     /[if lt IE 9]
       = javascript_include_tag "//html5shim.googlecode.com/svn/trunk/html5.js"
-    = javascript_include_tag "//maps.google.com/maps/api/js?sensor=false&language=#{I18n.locale}"
+    = javascript_include_tag "//maps.google.com/maps/api/js?sensor=false&language=#{I18n.locale}&key=#{ENV['GOOGLE_MAP_KEY']}"
     = javascript_include_tag "//ajax.googleapis.com/ajax/libs/jquery/1.8/jquery.min.js"
     = javascript_include_tag "//ajax.googleapis.com/ajax/libs/jqueryui/1.8/jquery-ui.min.js"
     = javascript_include_tag "application"


### PR DESCRIPTION
When I tried to standup this project on Heroku the map didn't work because as google now requires (as of two months ago) an API key for apps hosted on a domain:
 http://googlegeodevelopers.blogspot.com.au/2016/06/building-for-scale-updates-to-google.html

This PR adds support for adding a key, and instructions for setting it up on heroku.